### PR TITLE
Add MailerSend configuration and service for sending emails

### DIFF
--- a/Infrastructure/AWS/SES/Config/MailSettings.cs
+++ b/Infrastructure/AWS/SES/Config/MailSettings.cs
@@ -8,5 +8,8 @@ public class MailSettings
     public string? Mail { get; set; }
     public string? Username { get; set; }
     public string? Password { get; set; }
+    public string? MailerSendBaseUrl { get; set; }
+    public string? MailerSendApiKey { get; set; }
+
 }
 

--- a/Infrastructure/email/MailerSend.cs
+++ b/Infrastructure/email/MailerSend.cs
@@ -1,0 +1,54 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using api;
+using api.Domain.Services;
+using Microsoft.Extensions.Options;
+
+public class MailerSendService : IEMailService
+{
+    private readonly MailSettings _mailSettings;
+    private readonly ILogger<MailerSendService> _logger;
+    public MailerSendService(
+        IOptions<MailSettings> _mailSettings,
+         ILogger<MailerSendService> _logger
+        )
+    {
+        this._mailSettings = _mailSettings.Value;
+        this._logger = _logger;
+    }
+    public async Task SendBasicEmail(MailRequest mailRequest)
+    {
+        var body = new
+        {
+            from = new
+            {
+                email = _mailSettings.Mail,
+                name = _mailSettings.DisplayName
+            },
+            to = new[]
+            {
+                new
+                {
+                    email = mailRequest.ToEmail
+                }
+            },
+            subject = mailRequest.Subject,
+            text = mailRequest.Body
+        };
+
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _mailSettings.MailerSendApiKey);
+        var response = await client.PostAsJsonAsync($"{_mailSettings.MailerSendBaseUrl}/email", body);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+
+            _logger.LogError(content);
+
+            throw new Exception("Error sending email");
+        }
+
+
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -77,7 +77,8 @@ builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IBankRepository, BankRepository>();
 builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
 
-builder.Services.AddTransient<IEMailService, SesService>();
+//builder.Services.AddTransient<IEMailService, SesService>();
+builder.Services.AddTransient<IEMailService, MailerSendService>();
 builder.Services.AddScoped<IAuth, AuthService>();
 builder.Services.AddAWSService<IAmazonSimpleEmailService>();
 builder.Services.AddTransient<IHasher, HasherService>();


### PR DESCRIPTION
This pull request adds the necessary configuration and service implementation for sending emails using the MailerSend API. The `MailSettings` class has been updated to include properties for the MailerSend base URL and API key. Additionally, a new `MailerSendService` class has been added, which implements the `IEMailService` interface and handles the logic for sending basic emails using the MailerSend API. The existing email service implementation using SES has been commented out for now. 